### PR TITLE
docs(readme): README.md raiz copiado para lib após processo de build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,7 @@
     "build": "ng build ng-application-insights && cd projects/ng-application-insights && npm run build",
     "test": "ng test --no-watch",
     "lint": "ng lint",
-    "e2e": "ng e2e",
-    "copy:readme": "cp README.md dist/ng-application-insights",
-    "postbuild": "npm run copy:readme"
+    "e2e": "ng e2e"
   },
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "ng build ng-application-insights && cd projects/ng-application-insights && npm run build",
     "test": "ng test --no-watch",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "copy:readme": "cp README.md dist/ng-application-insights",
+    "postbuild": "npm run copy:readme"
   },
   "private": true,
   "dependencies": {

--- a/projects/ng-application-insights/package.json
+++ b/projects/ng-application-insights/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "build": "../../node_modules/.bin/tsc -p tsconfig.schematics.json",
     "copy:collection": "cp schematics/collection.json ../../dist/ng-application-insights/schematics/collection.json",
-    "postbuild": "npm run copy:collection"
+    "copy:readme": "cp ../../README.md ../../dist/ng-application-insights",
+    "postbuild": "npm run copy:collection && npm run copy:readme"
   },
   "peerDependencies": {
     "@angular/common": "^10.0.14",

--- a/projects/ng-application-insights/package.json
+++ b/projects/ng-application-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wizsolucoes/ng-application-insights",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/projects/ng-application-insights/package.json
+++ b/projects/ng-application-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wizsolucoes/ng-application-insights",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": false,
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
#5 Correção na documentação para publicação do pacote no npmjs.com. Após o processo de build da lib + schematics, arquivo README.md da raiz é copiado para a pasta destino da build.